### PR TITLE
Modified card sprite preload paths to use absolute path

### DIFF
--- a/src/Scenes/PreloadScene.js
+++ b/src/Scenes/PreloadScene.js
@@ -8,13 +8,13 @@ class PreloadScene extends Phaser.Scene {
     // ===== Phaser.Scene Overrides =====
 
     preload(){
-        this.load.image('deck', '../../Assets/card-back1.png');
+        this.load.image('deck', '/Assets/card-back1.png');
     
         // Load cards
         const suits = [ 'clubs', 'diamonds', 'hearts', 'spades' ];
         suits.forEach(suit => {
             for (let i = 1; i <= 13; i++)
-                this.load.image(`${suit}-${i}`, `../Assets/card-${suit}-${i}.png`);
+                this.load.image(`${suit}-${i}`, `/Assets/card-${suit}-${i}.png`);
         });
     }
 


### PR DESCRIPTION
### Related Issues
#16 

### Changes
- Modified sprite loading code in `PreloadScene.js` to use absolute paths of card images